### PR TITLE
Allow connection string setting on initialization

### DIFF
--- a/lib/entity_store_sequel/postgres_entity_store.rb
+++ b/lib/entity_store_sequel/postgres_entity_store.rb
@@ -37,12 +37,19 @@ module EntityStoreSequel
 
       def init
         migration_path = File.expand_path("../../sequel/migrations", __FILE__)
-        Sequel::Migrator.run(self.database, migration_path, :table=>:entity_store_schema_migration)
+        Sequel::Migrator.run(self.database, migration_path, table: :entity_store_schema_migration)
       end
     end
 
+    def initialize(database_connection = nil)
+      return unless database_connection
+
+      @database_connection = database_connection
+      @database_connection.extension :pg_json
+    end
+
     def open
-      PostgresEntityStore.database
+      @database_connection || PostgresEntityStore.database
     end
 
     def entities


### PR DESCRIPTION
This along with changes in entity store allow two databases to be used
for entity store